### PR TITLE
Consider included files when creating ignore list

### DIFF
--- a/lib/xcov/model/source.rb
+++ b/lib/xcov/model/source.rb
@@ -25,7 +25,10 @@ module Xcov
       @type = Source.type(name)
       @lines = lines
 
-      UI.message "Ignoring #{name} coverage".yellow if @ignored || !@included
+      @ignored = @ignored || !@included
+
+      UI.message "Including #{name} coverage".yellow if @included
+      UI.message "Ignoring #{name} coverage".red if @ignored 
     end
 
     def print_description


### PR DESCRIPTION
- This allows the `.xcovinclude` to be considered when creating the final ignore list
- This is functional but needs to address that fact that `.xcovignore` will always win in a conflict between `.xcovignore` and `.xcovinclude`. Could keep this as the default but provide a argument to allow `.xcovinclude` to rule.